### PR TITLE
Update 2012-12-27-android-adapter-good-practices.markdown

### DIFF
--- a/_posts/2012-12-27-android-adapter-good-practices.markdown
+++ b/_posts/2012-12-27-android-adapter-good-practices.markdown
@@ -280,7 +280,7 @@ public View getView(int position, View convertView, ViewGroup parent) {
 
 	bananaPhoneView.update(bananaPhone);
 
-	return convertView;
+	return bananaPhoneView; //make sure to return your typed view to facilitate view recycling
 }
 {% endhighlight %}
 


### PR DESCRIPTION
The original code would always return null for convertView and not allow for recycling to take place
